### PR TITLE
script to combine teacher annotations from 2 or >2 teachers

### DIFF
--- a/combineTeacherAnnotations/combineAnnotations.py
+++ b/combineTeacherAnnotations/combineAnnotations.py
@@ -1,0 +1,76 @@
+import json
+import pandas as pd
+import argparse
+
+def read_json_to_df(file_path):
+    # Read JSON lines
+    with open(file_path, 'r') as f:
+        data = [json.loads(line) for line in f]
+        # Use json_normalize to flatten nested dictionaries
+        df = pd.json_normalize(data)
+        # Rename columns to replace '.' with '_' for easier access
+        df.columns = df.columns.str.replace('.', '_', regex=False)
+        
+        return df
+
+
+
+def process_is_safe_columns(row):
+    is_safe_columns = [col for col in row.index if col.endswith('_is_safe')]
+    
+    if len(is_safe_columns) == 2:
+        # If there are exactly two columns, check if they're equal
+        if row[is_safe_columns[0]] == row[is_safe_columns[1]]:
+            return row[is_safe_columns[0]]
+        else:
+            return "disagree"
+    elif len(is_safe_columns) > 2:
+        # If there are more than two columns, use majority voting
+        votes = row[is_safe_columns].value_counts()
+        return votes.index[0] if votes.iloc[0] > len(is_safe_columns) // 2 else None
+    else:
+        # If there are fewer than two columns, return None
+        return "toofewcols"
+
+
+
+
+
+def process_json_files(file1_path, file2_path, output_file):
+    # Read JSON files into pandas DataFrames
+    df1 = read_json_to_df(file1_path)
+    df2 = read_json_to_df(file2_path)
+    
+    # # Combine DataFrames based on UID
+    combined_df = pd.concat([df1, df2]).groupby('UID', as_index=False).first()
+    
+
+    # # Apply the function to create a new column
+    combined_df['Is_Safe_Result'] = combined_df.apply(process_is_safe_columns, axis=1)
+    combined_df['Annotations_Agree'] = combined_df['Is_Safe_Result'].apply(lambda x: x not in ["disagree", "toofewcols"])
+
+    # Create DataFrames for agreements and disagreements
+    agreements_df = combined_df[combined_df['Annotations_Agree'] == True].copy()
+    disagreements_df = combined_df[combined_df['Annotations_Agree'] == False].copy()
+
+
+    combined_df.to_csv(output_file, index=False)
+    agreements_df.to_csv("agreements_" + output_file, index=False)
+    disagreements_df.to_csv("disagreements_" + output_file, index=False)
+
+
+    
+
+def main():
+    parser = argparse.ArgumentParser(description="Process JSON files and compare annotations.")
+    parser.add_argument("--file1",default="40k_alpaca_7b-llama-3-70b-annotations-20240718-080145.jsonl", help="Path to the first JSON file")
+    parser.add_argument("--file2", default="40k_alpaca_7b-mistral8x22b-annotations-20240720-151345.jsonl",help="Path to the second JSON file")
+    parser.add_argument("--output", default="mergedTeacherAnnotations_40k_Alpaca7b_new.csv", help="Suffix for output CSV files (default: output)")
+    args = parser.parse_args()
+
+    process_json_files(args.file1, args.file2, args.output)
+
+    print(f"Processing complete. CSV files have been saved with suffix '{args.output}'.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a script to merge annotations from json files containing prompts, responses, and safe/unsafe annotations (+metadata) from teacher models . 

- Reads json files as input
- Looks for columns ending with _is_safe annotations. 
- If 2 teachers, writes agreements and disagreements to different files. If >2 , takes majority votes and writes labels to an output file. 